### PR TITLE
Make dlist-instances compatible with dlist-0.8+

### DIFF
--- a/Data/DList/Instances.hs
+++ b/Data/DList/Instances.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.DList.Instances () where
 
+-- don't define instance for dlist>=0.8 && base>=4.9
+#if !(MIN_VERSION_base(4,9,0)) || !(MIN_VERSION_dlist(0,8,0))
 import Data.DList
 import Data.Semigroup
 
-instance Semigroup (DList a)
+instance Semigroup (DList a) where
+  (<>) = append
+#endif


### PR DESCRIPTION
Starting with dlist-0.8, a conditionally defined non-orphan instance for
Semigroup is provided. See https://github.com/spl/dlist/issues/25

This also refactors the code in a future-proof way taking into account
the Semigroup/Monoid superclass proposal.
